### PR TITLE
Add aria-label for screen reader accessibility

### DIFF
--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -1,10 +1,10 @@
 <li class="acl-write superscript">
-  <a title="superscript" class="grouped-left">
+  <a title="superscript" aria-label="superscript" data-l10n-id="ep_subscript_and_superscript.superscript" class="grouped-left">
     <span class="buttonicon buttonicon-superscript"></span>
   </a>
 </li>
 <li class="acl-write subscript">
-  <a title="subscript" class="grouped-right">
+  <a title="subscript" aria-label="subscript" data-l10n-id="ep_subscript_and_superscript.subscript" class="grouped-right">
     <span class="buttonicon buttonicon-subscript"></span>
   </a>
 </li>


### PR DESCRIPTION
## Summary

Adds `aria-label` to toolbar elements for screen reader accessibility, following the pattern established in ep_headings2.

## Test plan

- [ ] Screen reader announces the control label correctly
- [ ] Plugin functions normally after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)