### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ep_subscript_and_superscript
+# Subscript and Superscript for Etherpad
 
 ![Demo](demo.gif)
 


### PR DESCRIPTION
Replace the placeholder `ep_subscript_and_superscript` heading in README.md with "Subscript and Superscript for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.