### PR TITLE
a11y: flatten <a><span> toolbar buttons (restore localized aria-label)

### DIFF
--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -1,10 +1,12 @@
 <li class="acl-write superscript">
-  <a title="superscript" data-l10n-id="ep_subscript_and_superscript.superscript" class="grouped-left">
-    <span class="buttonicon buttonicon-superscript"></span>
-  </a>
+  <a class="grouped-left buttonicon buttonicon-superscript ep_subscript_and_superscript_super"
+     role="button" tabindex="0"
+     title="superscript"
+     data-l10n-id="ep_subscript_and_superscript.superscript"></a>
 </li>
 <li class="acl-write subscript">
-  <a title="subscript" data-l10n-id="ep_subscript_and_superscript.subscript" class="grouped-right">
-    <span class="buttonicon buttonicon-subscript"></span>
-  </a>
+  <a class="grouped-right buttonicon buttonicon-subscript ep_subscript_and_superscript_sub"
+     role="button" tabindex="0"
+     title="subscript"
+     data-l10n-id="ep_subscript_and_superscript.subscript"></a>
 </li>


### PR DESCRIPTION
## Summary

Flattens the `<a><span class="buttonicon ..."></span></a>` pattern to a single `<a>` carrying both the icon classes and `role="button"`/`tabindex="0"`. With no element children, etherpad's html10n auto-populates `aria-label` from the localized translation (`html10n.ts:665-678`).

**Why this PR exists:** the earlier Phase 3a sweep removed hardcoded `aria-label="superscript"`/`aria-label="subscript"` assuming html10n would fill them in. It does not, when the element has element children AND the `data-l10n-id` doesn't end in a recognized attribute suffix (`.title`/`.alt`/`.value`/`.placeholder`). Flattening the structure makes the auto-population fire.