### PR TITLE
fix: stop sub/super toolbar buttons rendering icon + localized text

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,13 +40,13 @@ exports.padInitToolbar = (hookName, args, cb) => {
 
   const superscriptButton = toolbar.button({
     command: 'sup',
-    localizationId: 'ep_subscript_and_superscript.superscript',
+    localizationId: 'ep_subscript_and_superscript.superscript.title',
     class: 'buttonicon buttonicon-superscript',
   });
 
   const subscriptButton = toolbar.button({
     command: 'sub',
-    localizationId: 'ep_subscript_and_superscript.subscript',
+    localizationId: 'ep_subscript_and_superscript.subscript.title',
     class: 'buttonicon buttonicon-subscript',
   });
 

--- a/locales/ar.json
+++ b/locales/ar.json
@@ -4,6 +4,6 @@
 			"Meno25"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "نص سفلي",
-	"ep_subscript_and_superscript.superscript": "نص علوي"
+	"ep_subscript_and_superscript.subscript.title": "نص سفلي",
+	"ep_subscript_and_superscript.superscript.title": "نص علوي"
 }

--- a/locales/be-tarask.json
+++ b/locales/be-tarask.json
@@ -4,6 +4,6 @@
 			"Renessaince"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Ніжні індэкс",
-	"ep_subscript_and_superscript.superscript": "Верхні індэкс"
+	"ep_subscript_and_superscript.subscript.title": "Ніжні індэкс",
+	"ep_subscript_and_superscript.superscript.title": "Верхні індэкс"
 }

--- a/locales/bn.json
+++ b/locales/bn.json
@@ -5,6 +5,6 @@
 			"আজিজ"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "নিম্নলিপি",
-	"ep_subscript_and_superscript.superscript": "ঊর্ধ্বলিপি"
+	"ep_subscript_and_superscript.subscript.title": "নিম্নলিপি",
+	"ep_subscript_and_superscript.superscript.title": "ঊর্ধ্বলিপি"
 }

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -5,6 +5,6 @@
 			"Vfc"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Subíndex",
-	"ep_subscript_and_superscript.superscript": "Superíndex"
+	"ep_subscript_and_superscript.subscript.title": "Subíndex",
+	"ep_subscript_and_superscript.superscript.title": "Superíndex"
 }

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -4,6 +4,6 @@
 			"Spotter"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Dolní index",
-	"ep_subscript_and_superscript.superscript": "Horní index"
+	"ep_subscript_and_superscript.subscript.title": "Dolní index",
+	"ep_subscript_and_superscript.superscript.title": "Horní index"
 }

--- a/locales/da.json
+++ b/locales/da.json
@@ -4,6 +4,6 @@
 			"Peterleth"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Sænket skrift",
-	"ep_subscript_and_superscript.superscript": "Hævet skrift"
+	"ep_subscript_and_superscript.subscript.title": "Sænket skrift",
+	"ep_subscript_and_superscript.superscript.title": "Hævet skrift"
 }

--- a/locales/dag.json
+++ b/locales/dag.json
@@ -4,6 +4,6 @@
 			"Anamzooya"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Bia din do gbunni",
-	"ep_subscript_and_superscript.superscript": "Bia din yili zuɣusaa"
+	"ep_subscript_and_superscript.subscript.title": "Bia din do gbunni",
+	"ep_subscript_and_superscript.superscript.title": "Bia din yili zuɣusaa"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -4,6 +4,6 @@
 			"FF-11"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Tiefgestellt",
-	"ep_subscript_and_superscript.superscript": "Hochgestellt"
+	"ep_subscript_and_superscript.subscript.title": "Tiefgestellt",
+	"ep_subscript_and_superscript.superscript.title": "Hochgestellt"
 }

--- a/locales/diq.json
+++ b/locales/diq.json
@@ -5,6 +5,6 @@
 			"Mirzali"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Bınnuşte",
-	"ep_subscript_and_superscript.superscript": "Sernuşte"
+	"ep_subscript_and_superscript.subscript.title": "Bınnuşte",
+	"ep_subscript_and_superscript.superscript.title": "Sernuşte"
 }

--- a/locales/dsb.json
+++ b/locales/dsb.json
@@ -4,6 +4,6 @@
 			"Michawiki"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Nižej stajony",
-	"ep_subscript_and_superscript.superscript": "Wušej stajony"
+	"ep_subscript_and_superscript.subscript.title": "Nižej stajony",
+	"ep_subscript_and_superscript.superscript.title": "Wušej stajony"
 }

--- a/locales/el.json
+++ b/locales/el.json
@@ -4,6 +4,6 @@
 			"Jimkats"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Δείκτης",
-	"ep_subscript_and_superscript.superscript": "Εκθέτης"
+	"ep_subscript_and_superscript.subscript.title": "Δείκτης",
+	"ep_subscript_and_superscript.superscript.title": "Εκθέτης"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,4 @@
 {
-  "ep_subscript_and_superscript.subscript" : "Subscript",
-  "ep_subscript_and_superscript.superscript" : "Superscript"
+  "ep_subscript_and_superscript.subscript.title" : "Subscript",
+  "ep_subscript_and_superscript.superscript.title" : "Superscript"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -4,6 +4,6 @@
 			"Ovruni"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Subíndice",
-	"ep_subscript_and_superscript.superscript": "Superíndice"
+	"ep_subscript_and_superscript.subscript.title": "Subíndice",
+	"ep_subscript_and_superscript.superscript.title": "Superíndice"
 }

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -4,6 +4,6 @@
 			"Izendegi"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "azpi-indizea",
-	"ep_subscript_and_superscript.superscript": "goi-indizea"
+	"ep_subscript_and_superscript.subscript.title": "azpi-indizea",
+	"ep_subscript_and_superscript.superscript.title": "goi-indizea"
 }

--- a/locales/fa.json
+++ b/locales/fa.json
@@ -4,6 +4,6 @@
 			"Darafsh"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "زیرنویس",
-	"ep_subscript_and_superscript.superscript": "بالانویس"
+	"ep_subscript_and_superscript.subscript.title": "زیرنویس",
+	"ep_subscript_and_superscript.superscript.title": "بالانویس"
 }

--- a/locales/ff.json
+++ b/locales/ff.json
@@ -4,6 +4,6 @@
 			"Ibrahima Malal Sarr"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Teppinol",
-	"ep_subscript_and_superscript.superscript": "Tiindindol"
+	"ep_subscript_and_superscript.subscript.title": "Teppinol",
+	"ep_subscript_and_superscript.superscript.title": "Tiindindol"
 }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -4,6 +4,6 @@
 			"Yupik"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Alaindeksi",
-	"ep_subscript_and_superscript.superscript": "Yläindeksi"
+	"ep_subscript_and_superscript.subscript.title": "Alaindeksi",
+	"ep_subscript_and_superscript.superscript.title": "Yläindeksi"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -4,6 +4,6 @@
 			"Verdy p"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Indice",
-	"ep_subscript_and_superscript.superscript": "Exposant"
+	"ep_subscript_and_superscript.subscript.title": "Indice",
+	"ep_subscript_and_superscript.superscript.title": "Exposant"
 }

--- a/locales/ga.json
+++ b/locales/ga.json
@@ -4,6 +4,6 @@
 			"Aindriu80"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Fo-scríbhinn",
-	"ep_subscript_and_superscript.superscript": "Forscríbhinn"
+	"ep_subscript_and_superscript.subscript.title": "Fo-scríbhinn",
+	"ep_subscript_and_superscript.superscript.title": "Forscríbhinn"
 }

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -4,6 +4,6 @@
 			"Ghose"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Subíndice",
-	"ep_subscript_and_superscript.superscript": "Superíndice"
+	"ep_subscript_and_superscript.subscript.title": "Subíndice",
+	"ep_subscript_and_superscript.superscript.title": "Superíndice"
 }

--- a/locales/he.json
+++ b/locales/he.json
@@ -5,6 +5,6 @@
 			"YaronSh"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "כתב תחתי",
-	"ep_subscript_and_superscript.superscript": "כתב עילי"
+	"ep_subscript_and_superscript.subscript.title": "כתב תחתי",
+	"ep_subscript_and_superscript.superscript.title": "כתב עילי"
 }

--- a/locales/hsb.json
+++ b/locales/hsb.json
@@ -4,6 +4,6 @@
 			"Michawiki"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Nišo stajeny",
-	"ep_subscript_and_superscript.superscript": "Wyše stajeny"
+	"ep_subscript_and_superscript.subscript.title": "Nišo stajeny",
+	"ep_subscript_and_superscript.superscript.title": "Wyše stajeny"
 }

--- a/locales/ia.json
+++ b/locales/ia.json
@@ -4,6 +4,6 @@
 			"McDutchie"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Subscripto",
-	"ep_subscript_and_superscript.superscript": "Superscripto"
+	"ep_subscript_and_superscript.subscript.title": "Subscripto",
+	"ep_subscript_and_superscript.superscript.title": "Superscripto"
 }

--- a/locales/id.json
+++ b/locales/id.json
@@ -4,6 +4,6 @@
 			"Atriwidada"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Sub skrip",
-	"ep_subscript_and_superscript.superscript": "Super skrip"
+	"ep_subscript_and_superscript.subscript.title": "Sub skrip",
+	"ep_subscript_and_superscript.superscript.title": "Super skrip"
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -4,6 +4,6 @@
 			"Beta16"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Pedice",
-	"ep_subscript_and_superscript.superscript": "Apice"
+	"ep_subscript_and_superscript.subscript.title": "Pedice",
+	"ep_subscript_and_superscript.superscript.title": "Apice"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -4,6 +4,6 @@
 			"Tamaki Wakita"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "下付き",
-	"ep_subscript_and_superscript.superscript": "上付き"
+	"ep_subscript_and_superscript.subscript.title": "下付き",
+	"ep_subscript_and_superscript.superscript.title": "上付き"
 }

--- a/locales/kaa.json
+++ b/locales/kaa.json
@@ -4,6 +4,6 @@
 			"Inabat Allanova"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Qatar astı",
-	"ep_subscript_and_superscript.superscript": "Qatar ústi"
+	"ep_subscript_and_superscript.subscript.title": "Qatar astı",
+	"ep_subscript_and_superscript.superscript.title": "Qatar ústi"
 }

--- a/locales/kn.json
+++ b/locales/kn.json
@@ -4,6 +4,6 @@
 			"ಮಲ್ನಾಡಾಚ್ ಕೊಂಕ್ಣೊ"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "ಕೆಳಬರಹ",
-	"ep_subscript_and_superscript.superscript": "ಮೇಲ್ಬರಹ"
+	"ep_subscript_and_superscript.subscript.title": "ಕೆಳಬರಹ",
+	"ep_subscript_and_superscript.superscript.title": "ಮೇಲ್ಬರಹ"
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -4,6 +4,6 @@
 			"Ykhwong"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "아래 첨자",
-	"ep_subscript_and_superscript.superscript": "위 첨자"
+	"ep_subscript_and_superscript.subscript.title": "아래 첨자",
+	"ep_subscript_and_superscript.superscript.title": "위 첨자"
 }

--- a/locales/krc.json
+++ b/locales/krc.json
@@ -4,6 +4,6 @@
 			"Къарачайлы"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Тизгин тюбю индекс",
-	"ep_subscript_and_superscript.superscript": "Тизгин башы индекс"
+	"ep_subscript_and_superscript.subscript.title": "Тизгин тюбю индекс",
+	"ep_subscript_and_superscript.superscript.title": "Тизгин башы индекс"
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -4,6 +4,6 @@
 			"Nokeoo"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Apatinis indeksas",
-	"ep_subscript_and_superscript.superscript": "Viršutinis indeksas"
+	"ep_subscript_and_superscript.subscript.title": "Apatinis indeksas",
+	"ep_subscript_and_superscript.superscript.title": "Viršutinis indeksas"
 }

--- a/locales/mk.json
+++ b/locales/mk.json
@@ -4,6 +4,6 @@
 			"Bjankuloski06"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Долен индекс",
-	"ep_subscript_and_superscript.superscript": "Горен индекс"
+	"ep_subscript_and_superscript.subscript.title": "Долен индекс",
+	"ep_subscript_and_superscript.superscript.title": "Горен индекс"
 }

--- a/locales/my.json
+++ b/locales/my.json
@@ -4,6 +4,6 @@
 			"Andibecker"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "စာလုံးသေး",
-	"ep_subscript_and_superscript.superscript": "လုံးကြီးတင်"
+	"ep_subscript_and_superscript.subscript.title": "စာလုံးသေး",
+	"ep_subscript_and_superscript.superscript.title": "လုံးကြီးတင်"
 }

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -4,6 +4,6 @@
 			"Jon Harald Søby"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Senket skrift",
-	"ep_subscript_and_superscript.superscript": "Hevet skrift"
+	"ep_subscript_and_superscript.subscript.title": "Senket skrift",
+	"ep_subscript_and_superscript.superscript.title": "Hevet skrift"
 }

--- a/locales/ne.json
+++ b/locales/ne.json
@@ -4,6 +4,6 @@
 			"बडा काजी"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "निम्नाङ्कित गर्ने",
-	"ep_subscript_and_superscript.superscript": "उच्चाङ्कित गर्ने"
+	"ep_subscript_and_superscript.subscript.title": "निम्नाङ्कित गर्ने",
+	"ep_subscript_and_superscript.superscript.title": "उच्चाङ्कित गर्ने"
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -4,6 +4,6 @@
 			"Spinster"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Subscript",
-	"ep_subscript_and_superscript.superscript": "Superscript"
+	"ep_subscript_and_superscript.subscript.title": "Subscript",
+	"ep_subscript_and_superscript.superscript.title": "Superscript"
 }

--- a/locales/om.json
+++ b/locales/om.json
@@ -4,6 +4,6 @@
 			"Ahrada2016"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Jalarfii",
-	"ep_subscript_and_superscript.superscript": "Irrarfii"
+	"ep_subscript_and_superscript.subscript.title": "Jalarfii",
+	"ep_subscript_and_superscript.superscript.title": "Irrarfii"
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -4,6 +4,6 @@
 			"Usagi.02808"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Indeks dolny",
-	"ep_subscript_and_superscript.superscript": "Indeks górny"
+	"ep_subscript_and_superscript.subscript.title": "Indeks dolny",
+	"ep_subscript_and_superscript.superscript.title": "Indeks górny"
 }

--- a/locales/pms.json
+++ b/locales/pms.json
@@ -4,6 +4,6 @@
 			"Borichèt"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Ìndes an bass",
-	"ep_subscript_and_superscript.superscript": "Ìndes an àut"
+	"ep_subscript_and_superscript.subscript.title": "Ìndes an bass",
+	"ep_subscript_and_superscript.superscript.title": "Ìndes an àut"
 }

--- a/locales/ps.json
+++ b/locales/ps.json
@@ -4,6 +4,6 @@
 			"شاه زمان پټان"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "ټيټليک",
-	"ep_subscript_and_superscript.superscript": "جگليک"
+	"ep_subscript_and_superscript.subscript.title": "ټيټليک",
+	"ep_subscript_and_superscript.superscript.title": "جگليک"
 }

--- a/locales/pt-br.json
+++ b/locales/pt-br.json
@@ -4,6 +4,6 @@
 			"Mariagarbin"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Subscrito",
-	"ep_subscript_and_superscript.superscript": "Sobrescrito"
+	"ep_subscript_and_superscript.subscript.title": "Subscrito",
+	"ep_subscript_and_superscript.superscript.title": "Sobrescrito"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -5,6 +5,6 @@
 			"Unamane"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Subscrito",
-	"ep_subscript_and_superscript.superscript": "Sobrescrito"
+	"ep_subscript_and_superscript.subscript.title": "Subscrito",
+	"ep_subscript_and_superscript.superscript.title": "Sobrescrito"
 }

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -4,6 +4,6 @@
 			"SZ475"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Indice",
-	"ep_subscript_and_superscript.superscript": "Exponent"
+	"ep_subscript_and_superscript.subscript.title": "Indice",
+	"ep_subscript_and_superscript.superscript.title": "Exponent"
 }

--- a/locales/roa-tara.json
+++ b/locales/roa-tara.json
@@ -4,6 +4,6 @@
 			"Joetaras"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Sottoscritte",
-	"ep_subscript_and_superscript.superscript": "Sovrascritte"
+	"ep_subscript_and_superscript.subscript.title": "Sottoscritte",
+	"ep_subscript_and_superscript.superscript.title": "Sovrascritte"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -4,6 +4,6 @@
 			"Okras"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Подстрочный индекс",
-	"ep_subscript_and_superscript.superscript": "Надстрочный индекс"
+	"ep_subscript_and_superscript.subscript.title": "Подстрочный индекс",
+	"ep_subscript_and_superscript.superscript.title": "Надстрочный индекс"
 }

--- a/locales/sc.json
+++ b/locales/sc.json
@@ -4,6 +4,6 @@
 			"Adr mm"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Subìnditze",
-	"ep_subscript_and_superscript.superscript": "Superìnditze"
+	"ep_subscript_and_superscript.subscript.title": "Subìnditze",
+	"ep_subscript_and_superscript.superscript.title": "Superìnditze"
 }

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -4,6 +4,6 @@
 			"Yardom78"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Dolný index",
-	"ep_subscript_and_superscript.superscript": "Horný index"
+	"ep_subscript_and_superscript.subscript.title": "Dolný index",
+	"ep_subscript_and_superscript.superscript.title": "Horný index"
 }

--- a/locales/skr-arab.json
+++ b/locales/skr-arab.json
@@ -4,6 +4,6 @@
 			"Saraiki"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "ذیلی لکھت",
-	"ep_subscript_and_superscript.superscript": "اتے لکھت"
+	"ep_subscript_and_superscript.subscript.title": "ذیلی لکھت",
+	"ep_subscript_and_superscript.superscript.title": "اتے لکھت"
 }

--- a/locales/sl.json
+++ b/locales/sl.json
@@ -4,6 +4,6 @@
 			"Eleassar"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Podpisano",
-	"ep_subscript_and_superscript.superscript": "Nadpisano"
+	"ep_subscript_and_superscript.subscript.title": "Podpisano",
+	"ep_subscript_and_superscript.superscript.title": "Nadpisano"
 }

--- a/locales/sq.json
+++ b/locales/sq.json
@@ -4,6 +4,6 @@
 			"Besnik b"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Subscript",
-	"ep_subscript_and_superscript.superscript": "Superscript"
+	"ep_subscript_and_superscript.subscript.title": "Subscript",
+	"ep_subscript_and_superscript.superscript.title": "Superscript"
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -4,6 +4,6 @@
 			"WikiPhoenix"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Nedsänkt",
-	"ep_subscript_and_superscript.superscript": "Upphöjd"
+	"ep_subscript_and_superscript.subscript.title": "Nedsänkt",
+	"ep_subscript_and_superscript.superscript.title": "Upphöjd"
 }

--- a/locales/sw.json
+++ b/locales/sw.json
@@ -4,6 +4,6 @@
 			"Andibecker"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Hati ndogo",
-	"ep_subscript_and_superscript.superscript": "Hati kuu"
+	"ep_subscript_and_superscript.subscript.title": "Hati ndogo",
+	"ep_subscript_and_superscript.superscript.title": "Hati kuu"
 }

--- a/locales/th.json
+++ b/locales/th.json
@@ -5,6 +5,6 @@
 			"Trisorn Triboon"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "ตัวห้อย",
-	"ep_subscript_and_superscript.superscript": "ตัวยก"
+	"ep_subscript_and_superscript.subscript.title": "ตัวห้อย",
+	"ep_subscript_and_superscript.superscript.title": "ตัวยก"
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -5,6 +5,6 @@
 			"SaldırganSincap"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Alt simge",
-	"ep_subscript_and_superscript.superscript": "Üst simge"
+	"ep_subscript_and_superscript.subscript.title": "Alt simge",
+	"ep_subscript_and_superscript.superscript.title": "Üst simge"
 }

--- a/locales/ug-arab.json
+++ b/locales/ug-arab.json
@@ -4,6 +4,6 @@
 			"Sahran"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "تۆۋەنكى ئىندېكس",
-	"ep_subscript_and_superscript.superscript": "يۇقىرى ئىندېكس"
+	"ep_subscript_and_superscript.subscript.title": "تۆۋەنكى ئىندېكس",
+	"ep_subscript_and_superscript.superscript.title": "يۇقىرى ئىندېكس"
 }

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -5,6 +5,6 @@
 			"Ice bulldog"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "Нижній індекс",
-	"ep_subscript_and_superscript.superscript": "Верхній індекс"
+	"ep_subscript_and_superscript.subscript.title": "Нижній індекс",
+	"ep_subscript_and_superscript.superscript.title": "Верхній індекс"
 }

--- a/locales/zh-hans.json
+++ b/locales/zh-hans.json
@@ -4,6 +4,6 @@
 			"列维劳德"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "下标",
-	"ep_subscript_and_superscript.superscript": "上标"
+	"ep_subscript_and_superscript.subscript.title": "下标",
+	"ep_subscript_and_superscript.superscript.title": "上标"
 }

--- a/locales/zh-hant.json
+++ b/locales/zh-hant.json
@@ -4,6 +4,6 @@
 			"Kly"
 		]
 	},
-	"ep_subscript_and_superscript.subscript": "下標",
-	"ep_subscript_and_superscript.superscript": "上標"
+	"ep_subscript_and_superscript.subscript.title": "下標",
+	"ep_subscript_and_superscript.superscript.title": "上標"
 }

--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -1,12 +1,12 @@
 <li class="acl-write superscript">
   <a class="grouped-left buttonicon buttonicon-superscript ep_subscript_and_superscript_super"
      role="button" tabindex="0"
-     title="superscript"
-     data-l10n-id="ep_subscript_and_superscript.superscript"></a>
+     title="Superscript"
+     data-l10n-id="ep_subscript_and_superscript.superscript.title"></a>
 </li>
 <li class="acl-write subscript">
   <a class="grouped-right buttonicon buttonicon-subscript ep_subscript_and_superscript_sub"
      role="button" tabindex="0"
-     title="subscript"
-     data-l10n-id="ep_subscript_and_superscript.subscript"></a>
+     title="Subscript"
+     data-l10n-id="ep_subscript_and_superscript.subscript.title"></a>
 </li>


### PR DESCRIPTION
## Summary

- The subscript/superscript toolbar buttons rendered both the fontawesome glyph (from `.buttonicon-(sub|super)script::before { content }`) **and** the localized "Subscript" / "Superscript" string overlapping side-by-side.
- Root cause: etherpad's html10n inspects the `data-l10n-id` suffix to decide which target to populate. Known suffixes (`.title`, `.placeholder`, `.alt`, etc.) set that HTML attribute; otherwise the value falls through to `textContent`. Our keys (`ep_subscript_and_superscript.subscript` / `.superscript`) had no recognized suffix → the localized string was injected as the `<a>`'s text and rendered alongside the `::before` icon glyph.
- Rename the locale keys to end in `.title` across all 58 locale files, update the EJS template's `data-l10n-id` attributes, and update the `toolbar.button({ localizationId })` calls in `index.js` to match. html10n now sets the `title` attribute (tooltip) instead of overwriting the button text.
- Also case-normalizes the fallback `title="Superscript"`/`"Subscript"` attributes so pre-i18n hover text matches the `en` locale value.

Compare with `ep_align`, which uses the `.title` convention (e.g. `ep_align.toolbar.left.title`) and renders correctly.

Translator impact: the *values* are unchanged — only the JSON keys are renamed. Existing translations are preserved 1:1; just shifted under the new key.

## Test plan

- [x] Buttons in the toolbar show only the icon (verified locally on etherpad 2.7.3 with the margin/colibris skins).
- [x] Hover tooltip still reads "Subscript" / "Superscript" (now from the `title` attribute populated via html10n, not the fallback HTML attribute).
- [ ] CI: lint + tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)